### PR TITLE
Improve step arguments

### DIFF
--- a/src/main/rascal/examples/modfun/Rename.rsc
+++ b/src/main/rascal/examples/modfun/Rename.rsc
@@ -178,7 +178,7 @@ set[Define] findAdditionalDefinitions(set[Define] cursorDefs, Tree tr, TModel tm
     return overloads;
 }
 
-void renameUses(set[Define] defs, str newName, Tree _, TModel tm, Renamer r) {
+void renameUses(set[Define] defs, str newName, TModel tm, Renamer r) {
     // Somehow, tm.useDef is empty, so we need to use tm.uses
     rel[loc, loc] defUse = {<d, u> | <Define _:<_, id, orgId, idRole, d, _>, use(id, orgId, u, _, _)> <- defs * toSet(tm.uses)};
 

--- a/src/main/rascal/examples/modfun/Rename.rsc
+++ b/src/main/rascal/examples/modfun/Rename.rsc
@@ -165,7 +165,7 @@ bool tryParse(type[&T <: Tree] tp, str s) {
 bool isValidName(moduleId(), str name) = tryParse(#ModId, name);
 bool isValidName(variableId(), str name) = tryParse(#Id, name);
 
-set[Define] findAdditionalDefinitions(set[Define] cursorDefs, Tree tr, TModel tm) {
+set[Define] findAdditionalDefinitions(set[Define] cursorDefs, Tree _, TModel tm, Renamer _) {
     set[Define] overloads = {};
     for (d <- tm.defines
       && d.idRole in cursorDefs.idRole

--- a/src/main/rascal/examples/modules/Rename.rsc
+++ b/src/main/rascal/examples/modules/Rename.rsc
@@ -124,7 +124,7 @@ tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] defs, list[Tree] curso
     return <defFiles, useFiles>;
 }
 
-void renameUses(set[Define] defs, str newName, Tree _, TModel tm, Renamer r) {
+void renameUses(set[Define] defs, str newName, TModel tm, Renamer r) {
     // Somehow, tm.useDef is empty, so we need to use tm.uses
     rel[loc, loc] defUse = {<d, u> | <Define _:<_, id, orgId, idRole, d, _>, use(id, orgId, u, _, _)> <- defs * toSet(tm.uses)};
 

--- a/src/main/rascal/refactor/Rename.rsc
+++ b/src/main/rascal/refactor/Rename.rsc
@@ -183,10 +183,11 @@ RenameResult rename(
         printDebug("+ Finding additional definitions");
         set[Define] additionalDefs = {};
         for (loc f <- maybeDefFiles) {
+            printDebug("  - ... in <f>");
             tr = parseLocCached(f);
             tm = getTModelCached(tr);
-            fileAdditionalDefs = findAdditionalDefinitions(defs, tr, tm);
-            printDebug("  - ... (<size(fileAdditionalDefs)>) in <f>");
+            fileAdditionalDefs = findAdditionalDefinitions(defs, tr, tm, r);
+            printDebug("    (found <size(fileAdditionalDefs)>)");
             additionalDefs += fileAdditionalDefs;
         }
         defs += additionalDefs;
@@ -292,7 +293,7 @@ default tuple[set[loc] defFiles, set[loc] useFiles] findOccurrenceFiles(set[Defi
     return <{f}, {f}>;
 }
 
-default set[Define] findAdditionalDefinitions(set[Define] cursorDefs, Tree tr, TModel tm) = {};
+default set[Define] findAdditionalDefinitions(set[Define] cursorDefs, Tree tr, TModel tm, Renamer r) = {};
 
 default void renameDefinition(Define d, loc nameLoc, str newName, TModel tm, Renamer r) {
     r.textEdit(replace(nameLoc, newName));

--- a/src/main/rascal/refactor/Rename.rsc
+++ b/src/main/rascal/refactor/Rename.rsc
@@ -204,7 +204,7 @@ RenameResult rename(
 
         map[Define, loc] defNames = defNameLocations(tr, fileDefs, r);
         for (d <- fileDefs) {
-            renameDefinition(d, defNames[d] ? d.defined, newName, tr, tm, r);
+            renameDefinition(d, defNames[d] ? d.defined, newName, tm, r);
         }
     }
     if (errorReported()) return <docEdits, getMessages()>;
@@ -216,7 +216,7 @@ RenameResult rename(
         tr = parseLocCached(f);
         tm = getTModelCached(tr);
 
-        renameUses(defs, newName, tr, tm, r);
+        renameUses(defs, newName, tm, r);
     }
 
     set[Message] convertedMessages = getMessages();
@@ -294,11 +294,11 @@ default tuple[set[loc] defFiles, set[loc] useFiles] findOccurrenceFiles(set[Defi
 
 default set[Define] findAdditionalDefinitions(set[Define] cursorDefs, Tree tr, TModel tm) = {};
 
-default void renameDefinition(Define d, loc nameLoc, str newName, Tree _, TModel tm, Renamer r) {
+default void renameDefinition(Define d, loc nameLoc, str newName, TModel tm, Renamer r) {
     r.textEdit(replace(nameLoc, newName));
 }
 
-default void renameUses(set[Define] defs, str newName, Tree _, TModel tm, Renamer r) {
+default void renameUses(set[Define] defs, str newName, TModel tm, Renamer r) {
     for (loc u <- invert(tm.useDef)[defs.defined] - defs.defined) {
         r.textEdit(replace(u, newName));
     }


### PR DESCRIPTION
- Remove the `Tree` argument from `renameDefinition`/`renameUses` to steer towards a `TModel`-based solution at this point in the analysis. The `Tree` can still be retrieved via a function in `Renamer::getConfig` when required.
- Add a missing `Renamer` argument to `findAdditionalDefinitions` to allow for messages reporting, config retrieval, etc.