### PR TITLE
Extend framework to allow analysis of occurrences of new name.

### DIFF
--- a/src/main/rascal/examples/modfun/RenameTest.rsc
+++ b/src/main/rascal/examples/modfun/RenameTest.rsc
@@ -55,8 +55,14 @@ void checkNoErrors(set[Message] msgs) {
     }
 }
 
-test bool moduleName() {
+test bool duplicateModuleName() {
     <edits, msgs> = basicRename("A", 1, 8, newName = "B");
+
+    return size({m | m <- msgs, m is error}) == 1;
+}
+
+test bool moduleName() {
+    <edits, msgs> = basicRename("A", 1, 8, newName = "C");
 
     checkNoErrors(msgs);
     return size(edits) == 2

--- a/src/main/rascal/examples/modules/Rename.rsc
+++ b/src/main/rascal/examples/modules/Rename.rsc
@@ -108,20 +108,27 @@ set[Define] getCursorDefinitions(list[Tree] cursor, Tree(loc) getTree, TModel(Tr
     return {};
 }
 
-tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] defs, list[Tree] cursor, Tree(loc) getTree, Renamer r) {
+tuple[set[loc], set[loc], set[loc]] findOccurrenceFiles(set[Define] defs, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) {
     set[loc] defFiles = {};
     set[loc] useFiles = {};
+    set[loc] newNameFiles = {};
 
     for (Define _:<_, name, _, idRole, _, _> <- defs) {
         for (loc f <- projectFiles(r.getConfig().pcfg)) {
             for (/Tree t := getTree(f)) {
-                if (just(<idRole, name>) := analyzeDef(t)) defFiles += f;
-                if (just(<idRole, name>) := analyzeUse(t)) useFiles += f;
+                if (just(<idRole, str n>) := analyzeDef(t)) {
+                    if (n == name) defFiles += f;
+                    else if (n == newName) newNameFiles += f;
+                }
+                if (just(<idRole, str n>) := analyzeUse(t)) {
+                    if (n == name) useFiles += f;
+                    else if (n == newName) newNameFiles += f;
+                }
             }
         }
     }
 
-    return <defFiles, useFiles>;
+    return <defFiles, useFiles, newNameFiles>;
 }
 
 void renameUses(set[Define] defs, str newName, Tree _, TModel tm, Renamer r) {

--- a/src/main/rascal/refactor/Rename.rsc
+++ b/src/main/rascal/refactor/Rename.rsc
@@ -215,7 +215,7 @@ RenameResult rename(
         tr = parseLocCached(f);
         validateNewNameOccurrences(defs, newName, tr, r);
     }
-    if (errorReported()) return <docEdits, getMessages()>;
+    if (errorReported()) return <sortDocEdits(docEdits), getMessages()>;
 
     defFiles = {d.defined.top | d <- defs};
 

--- a/src/main/rascal/refactor/Rename.rsc
+++ b/src/main/rascal/refactor/Rename.rsc
@@ -198,6 +198,7 @@ RenameResult rename(
         tr = parseLocCached(f);
         validateNewNameOccurrences(defs, newName, tr, r);
     }
+    if (errorReported()) return <docEdits, getMessages()>;
 
     defFiles = {d.defined.top | d <- defs};
 

--- a/src/main/rascal/refactor/Rename.rsc
+++ b/src/main/rascal/refactor/Rename.rsc
@@ -297,12 +297,16 @@ default tuple[set[loc] defFiles, set[loc] useFiles, set[loc] newNameFiles] findO
         return <{}, {}, {}>;
     }
 
-    return <{f}, {f}, {f}>;
+    return <{f}, {f}, any(/Tree t := f, "<t>" == newName) ? {f} : {}>;
 }
 
 default set[Define] findAdditionalDefinitions(set[Define] cursorDefs, Tree tr, TModel tm) = {};
 
-default void validateNewNameOccurrences(set[Define] cursorDefs, str newName, Tree _, Renamer r) {}
+default void validateNewNameOccurrences(set[Define] cursorDefs, str newName, Tree tr, Renamer r) {
+    for (Define d <- cursorDefs) {
+        r.error(d.defined, "Renaming this to \'<newName>\' would clash with use of \'<newName>\' in <tr.src.top>.");
+    }
+}
 
 default void renameDefinition(Define d, loc nameLoc, str newName, Tree _, TModel tm, Renamer r) {
     r.textEdit(replace(nameLoc, newName));


### PR DESCRIPTION
Based on a practical exploration with Rascal (https://github.com/usethesource/rascal-language-servers/pull/584), we extend the framework with functionality to analyse occurrences of the new name as entered by the user.