### PR TITLE
Report parse/type errors in files (and abort renaming).

### DIFF
--- a/src/main/rascal/refactor/Rename.rsc
+++ b/src/main/rascal/refactor/Rename.rsc
@@ -100,7 +100,11 @@ RenameResult rename(
     // Tree & TModel caching
 
     @memo{maximumSize(50)}
-    TModel getTModelCached(Tree t) = config.tmodelForTree(t);
+    TModel getTModelCached(Tree t) {
+        tm = config.tmodelForTree(t);
+        if (msg <- tm.messages, msg is error) registerMessage(error(t.src.top, "Renaming failed, since this file has type error(s)."));
+        return tm;
+    }
 
     @memo{maximumSize(50)}
     Tree parseLocCached(loc l) {
@@ -109,7 +113,12 @@ RenameResult rename(
             return cursor[-1];
         }
 
-        return config.parseLoc(l);
+        try {
+            return config.parseLoc(l);
+        } catch ParseError(_): {
+            registerMessage(error(t.src.top, "Renaming failed, since an error occurred while parsing this file."));
+            return char(-1);
+        }
     }
 
     // Make sure user uses cached functions


### PR DESCRIPTION
If a file has parse/type check errors, report a global (per-file) error and abort the renaming.